### PR TITLE
improvement: copy build files first to optimise cache hits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@ FROM node:14.13.1-alpine@sha256:9a28dee760ed940c6b72bd0b5aca05cdb04a05f4328f6308
 
 WORKDIR /srv/app/
 
-COPY ./ ./
+# copy package files first to increase build cache hits
+COPY ./package.json ./yarn.lock ./
 
 RUN yarn install
+
+COPY ./ ./
 
 EXPOSE 8080
 


### PR DESCRIPTION
Just a suggestion here, if you copy the build files and run the `yarn install` first, the next time you'll change source code under `./src` directory Docker will be able to take advantage of the image layer cache. You'll save 15 seconds of image build time if you don't change project dependecies.

Hope this helps @dargmuesli, keep up the good work!